### PR TITLE
added edit function and commonized groups/new and groups/edit form

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,5 +1,6 @@
 class GroupsController < ApplicationController
   before_action :set_group, only: [:edit, :update]
+  before_action :set_users, only: [:new, :edit]
   def index
   end
   
@@ -35,5 +36,9 @@ class GroupsController < ApplicationController
 
   def set_group
     @group = Group.find(params[:id])
+  end
+
+  def set_users
+    @users = User.all
   end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,4 +1,5 @@
 class GroupsController < ApplicationController
+  before_action :set_group, only: [:edit, :update]
   def index
   end
   
@@ -12,7 +13,7 @@ class GroupsController < ApplicationController
     if @group.save
       redirect_to :root, notice: 'グループを作成しました'
     else
-      render :new, alert: 'グループ作成に失敗しました'
+      render :new
     end
   end
 
@@ -20,10 +21,19 @@ class GroupsController < ApplicationController
   end
 
   def update
+    if @group.update(group_params)
+      redirect_to group_messages_path(@group), notice: 'グループを編集しました'
+    else
+      render :edit
+    end
   end
 
   private
   def group_params
     params.require(:group).permit(:name, user_ids: [])
+  end
+
+  def set_group
+    @group = Group.find(params[:id])
   end
 end

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -12,13 +12,12 @@
       = f.label :name, "グループ名", class: 'chat-group-form__field--left__label'
     .chat-group-form__field--right
       = f.text_field :name, class: 'chat__group_name chat-group-form__field--left__input', placeholder: "グループ名を入力してください"
-  .chat-group-form__field.clearfix
 
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
       = f.label :name, "チャットメンバー", class: 'chat-group-form__field--left__label'
     .chat-group-form__field--right
-      = f.collection_check_boxes :user_ids, User.all, :id, :name
+      = f.collection_check_boxes :user_ids, users, :id, :name
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -1,0 +1,25 @@
+= form_for group do |f|
+  - if group.errors.any?
+    .chat-group-form__errors
+      %h2
+      = "#{group.errors.full_messages.count}件のエラーが発生しました。"
+      %ul
+        - group.errors.full_messages.each do |message|
+          %li
+          = message
+  .chat-group-form__field.clearfix
+    .chat-group-form__field--left
+      = f.label :name, "グループ名", class: 'chat-group-form__field--left__label'
+    .chat-group-form__field--right
+      = f.text_field :name, class: 'chat__group_name chat-group-form__field--left__input', placeholder: "グループ名を入力してください"
+  .chat-group-form__field.clearfix
+
+  .chat-group-form__field.clearfix
+    .chat-group-form__field--left
+      = f.label :name, "チャットメンバー", class: 'chat-group-form__field--left__label'
+    .chat-group-form__field--right
+      = f.collection_check_boxes :user_ids, User.all, :id, :name
+  .chat-group-form__field.clearfix
+    .chat-group-form__field--left
+    .chat-group-form__field--right
+      = f.submit class: 'chat-group-form__field--right__action-btn'

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,0 +1,3 @@
+.chat-group-form
+  %h1 チャットグループ編集
+  = render "groups/form", {group: @group}

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,3 +1,3 @@
 .chat-group-form
   %h1 チャットグループ編集
-  = render "groups/form", {group: @group}
+  = render "groups/form", {group: @group, users: @users}

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,3 +1,3 @@
 .chat-group-form
   %h1 新規チャットグループ
-  = render "groups/form", {group: @group}
+  = render "groups/form", {group: @group, users: @users}

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,27 +1,3 @@
 .chat-group-form
   %h1 新規チャットグループ
-  = form_for @group do |f|
-    - if @group.errors.any?
-      .chat-group-form__errors
-        %h2
-        = "#{@group.errors.full_messages.count}件のエラーが発生しました。"
-        %ul
-          - @group.errors.full_messages.each do |message|
-            %li
-            = message
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-        = f.label :name, "グループ名", class: 'chat-group-form__field--left__label'
-      .chat-group-form__field--right
-        = f.text_field :name, class: 'chat__group_name chat-group-form__field--left__input', placeholder: "グループ名を入力してください"
-    .chat-group-form__field.clearfix
-
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-        = f.label :name, "チャットメンバー", class: 'chat-group-form__field--left__label'
-      .chat-group-form__field--right
-        = f.collection_check_boxes :user_ids, User.all, :id, :name
-    .chat-group-form__field.clearfix
-      .chat-group-form__field--left
-      .chat-group-form__field--right
-        = f.submit class: 'chat-group-form__field--right__action-btn'
+  = render "groups/form", {group: @group}


### PR DESCRIPTION
## WHAT
- グループコントローラにeditとupdateアクションを追加した
- groups/newとgroups/editのフォームを共通化し、部分テンプレートgroups/_formに記述した

## WHY
- グループ機能の編集を行えるようにするため
- 共通部分を部分テンプレート化して無駄を減らすため

※groups/:id/messageにあるEditボタンの編集については今回は行わず(カリキュラムで書いてあった)、groups/:id/editのURLを直接打ち込んで作業した

![image](https://user-images.githubusercontent.com/26789049/47599984-8caa0380-d9f4-11e8-9b8b-f7ce196030a6.png)
![image](https://user-images.githubusercontent.com/26789049/47599988-93d11180-d9f4-11e8-8ce5-b08512dceef6.png)
