### PR TITLE
Messagesコントローラのテスト(createアクション)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ group :development, :test do
   gem 'factory_bot_rails'
   gem 'rails-controller-testing'
   gem 'faker'
+  gem 'database_cleaner'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,7 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.0.5)
     crass (1.0.3)
+    database_cleaner (1.7.0)
     devise (4.4.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -258,6 +259,7 @@ DEPENDENCIES
   capybara (~> 2.13)
   carrierwave
   coffee-rails (~> 4.2)
+  database_cleaner
   devise
   erb2haml
   factory_bot_rails

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -3,7 +3,7 @@ class Group < ApplicationRecord
   has_many :users, through: :group_users
   has_many :messages
   
-  validates :name, presence: true, uniqueness: :true
+  validates :name, presence: true, uniqueness: true
 
   def show_last_message
     if (last_message = messages.last).present?

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'spec_helper'
 describe MessagesController do
   let(:user) {create(:user)}
   let(:group) {create(:group)}
@@ -11,15 +12,15 @@ describe MessagesController do
         get :index, params: {group_id: group.id}
       end
 
-      it "assigns the requested message to @message" do
+      it 'assigns the requested message to @message' do
         expect(assigns(:message)).to be_a_new(Message)
       end
 
-      it "assigns the requested group to @group" do
+      it 'assigns the requested group to @group' do
         expect(assigns(:group)).to eq group
       end
 
-      it "reders the :index template" do
+      it 'renders the :index template' do
         expect(response).to render_template :index
       end
 
@@ -30,7 +31,56 @@ describe MessagesController do
         get :index, params: {group_id: group.id}
       end
 
-      it "redirects to new_user_session_path" do
+      it 'redirects to new_user_session_path' do
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe 'POST #create' do
+    let(:params) { {group_id: group.id, user_id: user.id, message: attributes_for(:message)} }
+
+    context 'log in' do
+      before do
+        login_user(user)
+      end
+
+      context 'can save' do
+        subject {
+          post :create, params: params
+        }
+
+        it 'saves the new message in the database' do
+          expect{subject}.to change(Message, :count).by(1)
+        end
+
+        it 'redirects to group_messages_path' do
+          subject
+          expect(response).to redirect_to(group_messages_path)
+        end
+      end
+
+      context 'cannot save' do
+        let(:invalid_params) {{ group_id: group.id, user_id: user.id, message: attributes_for(:message, body: nil, image: nil)}}
+
+        subject {
+          post :create, params: invalid_params
+        }
+
+        it 'unsave the new message in the database' do
+          expect{subject}.to_not change(Message, :count)
+        end
+
+        it 'renders the :index template' do
+          subject
+          expect(response).to redirect_to(group_messages_path)
+        end
+      end
+    end
+
+    context 'not log in' do
+      it 'redirects to new_user_session_path' do
+        post :create, params: params
         expect(response).to redirect_to(new_user_session_path)
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,12 +1,20 @@
+require 'database_cleaner'
+
 RSpec.configure do |config|
+
+  config.before(:suite) do
+   DatabaseCleaner.strategy = :truncation
+ end
+
+ config.before(:each) do
+   DatabaseCleaner.start
+ end
+
+ config.after(:each) do
+   DatabaseCleaner.clean
+ end
+
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end
-
-  config.mock_with :rspec do |mocks|
-    mocks.verify_partial_doubles = true
-  end
-
-  config.shared_context_metadata_behavior = :apply_to_host_groups
-
 end


### PR DESCRIPTION
## WHAT
- createアクションのテストコードを記述した
- database_cleanerが消えてしまったので再インストールし、適切箇所の設定を行った
- groupモデルの:nameバリデーションのスペルミスを直した

## WHY
Messagesコントローラのcreateアクションが正しく作動するか確認するため
(コントローラのテストコードを書く練習のため)